### PR TITLE
SECRET_KEYの記述を削除

### DIFF
--- a/Team2021/settings.py
+++ b/Team2021/settings.py
@@ -12,7 +12,7 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 
 import os
 
-from Team2021 import dbUserData
+from . import dbUserData
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -125,10 +125,10 @@ USE_TZ = True
 STATIC_URL = '/static/'
 
 STATICFILES_DIRS = (
-    os.path.join(BASE_DIR, '../static'),
+    os.path.join(BASE_DIR+'../static/'),
 )
 
 try:
-    from .local_settings import *
+    from . import local_secret_key
 except ImportError:
     pass


### PR DESCRIPTION
setting.pyからSECRET_KEYの記述を削除
代わりに、local_secret_key.pyに記述を移します。
generated_local_secret_key.pyを実行してSECRET_KEYを生成してください。